### PR TITLE
[development] click CLI + some styling in responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,16 +128,22 @@ pipeline:
 
 ## Rules
 ### Etymology:
-JiggyRule - JiggyRule.rule consists of 3 characters (i.e.) X01
+`JiggyRule` - JiggyRule.rule consists of 3 characters (i.e.) `X01`
+
 
 X: (char) - letter describes corresponding ruleset
+
 0: (digit) - incrementing based on third digit
+
 0: (digit) - incrementing
 
-(i.e.) Playbook INFO Ruleset
 
-Rule 1. PlaybookHasName
+Examples:
+
+Rule: `PlaybookHasName`
+
 rule.rule = I (info) 0 (base 10) 1 (rule number 1)
 
-Rule 2. PipelineHasDescription
+Rule: `PipelineHasDescription`
+
 rule.rule = P (pipeline) 0 (base 10) 1 (rule number 1)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <p align="center"> jpl - JiggyPlaybookLinter </p>
+# <p align="center"> JiggyPlaybookLinter </p>
 
 <p align="center">
 <a href="https://travis-ci.com/thejig/jpl"><img alt="Build Status" src="https://travis-ci.com/thejig/jpl.svg?branch=master"></a>
@@ -103,7 +103,7 @@ A `JiggyPlaybook` is broken down into chunks
 
 ```yaml
 name: Hello, world!
-author: me@jigg.dev
+author: me@jiggy.dev
 description: Show off the usage of jpl
 version: 0.0.1
 
@@ -114,7 +114,7 @@ pipeline:
     source: jiggy.EnvSecrets
   tasks:
 
-  - name: print-somethin
+  - name: print-something
     description: Print something
     function:
       source: examples.utils.string_manipulation.PrintThis

--- a/README.md
+++ b/README.md
@@ -1,2 +1,143 @@
-# jpl
-Jiggy Playbook Linter
+# <p align="center"> jpl </p>
+
+<p align="center">
+<a href="https://travis-ci.com/thejig/jpl"><img alt="Build Status" src="https://travis-ci.com/thejig/jpl.svg?branch=master"></a>
+<a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+<a href="https://coveralls.io/github/thejig/jpl?branch=master"><img alt="Coverage Status" src="https://coveralls.io/repos/github/thejig/jpl/badge.svg?branch=master"></a>
+</p>
+
+
+## Description
+Use Jiggy? Want to validate your playbook before deploying a pipeline?
+`jpl` or the `JiggyPipelineLinter` allows you to validate your JiggyPlaybook outside of an execution.
+
+
+## Installation
+From Source
+```bash
+$ git clone https://github.com/thejig/jpl.git
+$ cd jpl
+$ python3.7 -m venv venv
+$ source venv/bin/activate
+$ pip install -e .
+```
+
+From Build
+* Coming Soon!
+```bash
+$ pip install jpl
+```
+
+## Usage
+Via CLI
+* `jpl` has a CLI for easy usage
+```bash
+$ jpl --help
+
+Usage: jpl [OPTIONS]
+
+  Click CLI entrypoint to run JiggyPlaybookLint.
+
+  CLI Args:
+  -v --verbose: Run `jpl` with verbosity.
+  -s --skip: Skip "PASSED" rules in JiggyPlaybookLint Report.
+  -p --playbook: Location of JiggyPlaybook to lint.
+
+  Returns:
+
+      click.echo - `with style`
+
+Options:
+  -v, --verbose        Run `jpl` with verbosity.
+  -s, --skip           Skip `PASSED` rules in jpl report
+  -p, --playbook TEXT  Filepath to Jiggy Playbook  [required]
+  --help               Show this message and exit.
+```
+
+A minimal test case
+```bash
+$ jpl -v -p ecamples/jiggy-playbook.yml
+
+  /\ \      /\  == \    /\ \
+ _\_\ \     \ \  _-/    \ \ \____
+/\_____\     \ \_\       \ \_____\
+\/_____/iggy  \/_/laybook \/_____/inter
+
+[F01] FunctionSourceExists - get-weekday:         FAILED      Declared path to function: `examples.utils.dates.GetWeekdayTask` does not exist.
+
+```
+
+Via python client
+```python
+import jpl
+
+>>> client = jpl.JiggyPlaybookLint(path="path/to/playbook")
+>>> client.run()
+```
+
+```bash
+   __        ______      __
+  /\ \      /\  == \    /\ \
+ _\_\ \     \ \  _-/    \ \ \____
+/\_____\     \ \_\       \ \_____\
+\/_____/iggy  \/_/laybook \/_____/inter
+
+[F01] FunctionSourceExists - get-weekday:         FAILED      Declared path to function: `examples.utils.dates.GetWeekdayTask` does not exist.
+```
+
+## Overview
+A `JiggyPlaybook` is broken down into chunks
+
+* Pipeline
+    * The entire `.yml` constitutes the "playbook"
+
+* Pipeline
+    * The key `pipeline` including all `tasks` constitutes the "pipeline"
+
+* Task
+    * Tasks are chunks of a pipeline having the below attributes:
+        * `name`
+        * `description`
+        * `function` which contains `source`, `params`, `output`
+        * `requires`
+
+```yaml
+name: Hello, world!
+author: me@jigg.dev
+description: Show off the usage of jpl
+version: 0.0.1
+
+pipeline:
+  runner: sequential
+  secrets:
+    location: examples/secrets/.env-example
+    source: jiggy.EnvSecrets
+  tasks:
+
+  - name: print-somethin
+    description: Print something
+    function:
+      source: examples.utils.string_manipulation.PrintThis
+      params:
+      - type: str
+        value: 'THIS PIPELINE IS GREAT'
+      output: null
+    requires: null
+
+```
+
+## Rules
+### Etymology:
+JiggyRule - JiggyRule.rule consists of 3 characters (i.e.) X01
+
+X: (char) - letter describes corresponding ruleset
+0: (digit) - incrementing based on third digit
+0: (digit) - incrementing
+
+(i.e.) Playbook INFO Ruleset
+
+Rule 1. PlaybookHasName
+rule.rule = I (info) 0 (base 10) 1 (rule number 1)
+
+Rule 2. PipelineHasDescription
+rule.rule = P (pipeline) 0 (base 10) 1 (rule number 1)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <p align="center"> jpl </p>
+# <p align="center"> jpl - JiggyPlaybookLinter </p>
 
 <p align="center">
 <a href="https://travis-ci.com/thejig/jpl"><img alt="Build Status" src="https://travis-ci.com/thejig/jpl.svg?branch=master"></a>
@@ -9,7 +9,7 @@
 
 ## Description
 Use Jiggy? Want to validate your playbook before deploying a pipeline?
-`jpl` or the `JiggyPipelineLinter` allows you to validate your JiggyPlaybook outside of an execution.
+`jpl` or the `JiggyPlaybookLinter` allows you to validate your JiggyPlaybook outside of an execution.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ import jpl
 ## Overview
 A `JiggyPlaybook` is broken down into chunks
 
-* Pipeline
+* Playbook 
     * The entire `.yml` constitutes the "playbook"
 
 * Pipeline
@@ -131,19 +131,19 @@ pipeline:
 `JiggyRule` - JiggyRule.rule consists of 3 characters (i.e.) `X01`
 
 
-X: (char) - letter describes corresponding ruleset
+* X: (char) - letter describes corresponding ruleset
 
-0: (digit) - incrementing based on third digit
+* 0: (digit) - incrementing based on third digit
 
-0: (digit) - incrementing
+* 0: (digit) - incrementing
 
 
 Examples:
 
 Rule: `PlaybookHasName`
 
-rule.rule = I (info) 0 (base 10) 1 (rule number 1)
+* rule.rule = I (info) 0 (base 10) 1 (rule number 1)
 
 Rule: `PipelineHasDescription`
 
-rule.rule = P (pipeline) 0 (base 10) 1 (rule number 1)
+* rule.rule = P (pipeline) 0 (base 10) 1 (rule number 1)

--- a/jpl/__init__.py
+++ b/jpl/__init__.py
@@ -7,28 +7,16 @@ from jpl.rules import PlayBookExists, rules, task_rules
 class JiggyPlaybookLint(object):  # pragma no cover
     """Runner for jpl."""
 
-    def __init__(self, path: str, skip=None, drop_passed=None, verbose=None):
+    def __init__(self, path: str, skip=None):
         self.playbook = self._read(path)
         self.skip = skip
-        self.drop_passed = drop_passed
-        self.verbose = verbose
 
     def run(self):
         """Runner for JiggyPlaybookLinter."""
-        print(
-            """
-   __        ______      __        
-  /\ \      /\  == \    /\ \       
- _\_\ \     \ \  _-/    \ \ \____  
-/\_____\     \ \_\       \ \_____\ 
-\/_____/iggy  \/_/laybook \/_____/inter            
-            """
-        )
-
         pbe = PlayBookExists()
         exists = pbe.run(self.playbook)
         if exists == "FAILED":
-            return self._parse_linted([(exists, pbe, None)], verbose=self.verbose)
+            return [(exists, pbe, None)]
 
         linted = []
         for rule in rules:
@@ -45,31 +33,10 @@ class JiggyPlaybookLint(object):  # pragma no cover
                 _status = init_rule.run(playbook=task)
                 linted.append((_status, init_rule, task.get("name")))
 
-        if self.drop_passed:
+        if self.skip:
             linted = [rule for rule in linted if rule[0] != "PASSED"]
 
-        return self._parse_linted(linted=linted, verbose=self.verbose)
-
-    @staticmethod
-    def _parse_linted(linted: list, verbose=None):  # pragma no cover
-        """
-        Parse rule responses to generate response object
-        :param linted:
-        :return:
-        """
-        for mark, rule, task_name in linted:
-            rule_meta = "[{}] {}:".format(rule.rule, rule.__class__.__name__)
-            if task_name:
-                rule_meta = "[{}] {} - {}:".format(
-                    rule.rule, rule.__class__.__name__, task_name
-                )
-
-            if verbose:
-                print("{:<50}{:<10} {}".format(rule_meta, mark, rule.message))
-            else:
-                print("{:<50}{:<50}".format(rule_meta, mark))
-
-        return "Done !!"
+        return linted
 
     @staticmethod
     def _read(path: str):  # pragma no cover

--- a/jpl/__main__.py
+++ b/jpl/__main__.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
 # NOTE: this is temporary runner
-import os
-import sys
-
-import jpl
-
-
-if sys.path[0] == "" or sys.path[0] == os.getcwd():
-    sys.path.pop(0)
+# import os
+# import sys
+#
+# import jpl
 
 
-if __name__ == "__main__":
-    if not sys.argv[-1].endswith(".yml"):
-        print("Please enter filepath to .yml")
-        sys.exit()
-    else:
-        jpl.JiggyPlaybookLint(path=sys.argv[-1], verbose=True, drop_passed=True).run()
+# if sys.path[0] == "" or sys.path[0] == os.getcwd():
+#     sys.path.pop(0)
+#
+#
+# if __name__ == "__main__":
+#     if not sys.argv[-1].endswith(".yml"):
+#         print("Please enter filepath to .yml")
+#         sys.exit()
+#     else:
+#         jpl.JiggyPlaybookLint(path=sys.argv[-1], verbose=True, drop_passed=True).run()

--- a/jpl/__main__.py
+++ b/jpl/__main__.py
@@ -1,18 +1,21 @@
-#!/usr/bin/env python
-# NOTE: this is temporary runner
-# import os
-# import sys
-#
-# import jpl
+"""Entry point for non-CLI calls."""
+import os
+import sys
+import jpl
 
 
-# if sys.path[0] == "" or sys.path[0] == os.getcwd():
-#     sys.path.pop(0)
-#
-#
-# if __name__ == "__main__":
-#     if not sys.argv[-1].endswith(".yml"):
-#         print("Please enter filepath to .yml")
-#         sys.exit()
-#     else:
-#         jpl.JiggyPlaybookLint(path=sys.argv[-1], verbose=True, drop_passed=True).run()
+def main():
+    """Entrypoint to the `jpl` main command."""
+
+    if sys.path[0] == "" or sys.path[0] == os.getcwd():
+        sys.path.pop(0)
+
+    if not sys.argv[-1].endswith(".yml"):
+        print("Please enter filepath to .yml")
+        sys.exit()
+    else:
+        jpl.JiggyPlaybookLint(path=sys.argv[-1]).run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/jpl/cli/main_cli.py
+++ b/jpl/cli/main_cli.py
@@ -13,25 +13,25 @@ MARK_TO_COLOR = {"PASSED": "green", "WARNING": "yellow", "FAILED": "red"}
     "-s",
     "--skip",
     required=False,
-    default="true",
+    is_flag=True,
+    default=True,
     help="Skip `PASSED` rules in jpl report",
 )
 @click.option("-p", "--playbook", required=True, help="Filepath to Jiggy Playbook")
 def lint(verbose, skip, playbook):
-    """
-    Click CLI entrypoint to run JiggyPlaybookLint.
+    """Click CLI entrypoint to run JiggyPlaybookLint.
 
     CLI Args:
-        -v --verbose: Run `jpl` with verbosity.
-        -s --skip: Skip "PASSED" rules in JiggyPlaybookLint Report.
-        -p --playbook: Location of JiggyPlaybook to lint.
 
-    Args:
-        verbose: (count) - flag to denote response with verbosity
-        skip: (str) - Skip "PASSED" rules in JiggyPlaybookLint Report.
-        playbook: (str) - Location of JiggyPlaybook to lint.
+    -v --verbose: Run `jpl` with verbosity.
+
+    -s --skip: Skip "PASSED" rules in JiggyPlaybookLint Report.
+
+    -p --playbook: Location of JiggyPlaybook to lint.
+
 
     Returns:
+
         click.echo - `with style`
     """
     click.echo(
@@ -43,9 +43,7 @@ def lint(verbose, skip, playbook):
 \/_____/iggy  \/_/laybook \/_____/inter            
         """
     )
-    linted = jpl.JiggyPlaybookLint(
-        path=playbook, skip=bool(skip.lower() in ["true", True])
-    ).run()
+    linted = jpl.JiggyPlaybookLint(path=playbook, skip=skip).run()
 
     generate_jpl_report(linted=linted, verbose=verbose)
 
@@ -68,12 +66,22 @@ def generate_jpl_report(linted: list, verbose=None):  # pragma no cover
                 rule.rule, rule.__class__.__name__, task_name
             )
 
-        if verbose:
+        if verbose == 1:
             click.echo(
                 "{:<50}{:<20} {}".format(
                     rule_meta,
                     click.style(mark, fg=MARK_TO_COLOR.get(mark)),
                     rule.message,
+                )
+            )
+        elif verbose > 1:
+            click.echo(
+                "{:<50}{:<20} {} \nPriority: `{}` - Description: `{}`\n".format(
+                    rule_meta,
+                    click.style(mark, fg=MARK_TO_COLOR.get(mark)),
+                    rule.message,
+                    rule.priority,
+                    rule.description,
                 )
             )
         else:

--- a/jpl/cli/main_cli.py
+++ b/jpl/cli/main_cli.py
@@ -1,0 +1,86 @@
+"""Jiggy Playbook Lint Command Line Interface"""
+import click
+import jpl
+
+MARK_TO_COLOR = {"PASSED": "green", "WARNING": "yellow", "FAILED": "red"}
+
+
+@click.command()
+@click.option(
+    "-v", "--verbose", required=False, count=True, help="Run `jpl` with verbosity."
+)
+@click.option(
+    "-s",
+    "--skip",
+    required=False,
+    default="true",
+    help="Skip `PASSED` rules in jpl report",
+)
+@click.option("-p", "--playbook", required=True, help="Filepath to Jiggy Playbook")
+def lint(verbose, skip, playbook):
+    """
+    Click CLI entrypoint to run JiggyPlaybookLint.
+
+    CLI Args:
+        -v --verbose: Run `jpl` with verbosity.
+        -s --skip: Skip "PASSED" rules in JiggyPlaybookLint Report.
+        -p --playbook: Location of JiggyPlaybook to lint.
+
+    Args:
+        verbose: (count) - flag to denote response with verbosity
+        skip: (str) - Skip "PASSED" rules in JiggyPlaybookLint Report.
+        playbook: (str) - Location of JiggyPlaybook to lint.
+
+    Returns:
+        click.echo - `with style`
+    """
+    click.echo(
+        """
+   __        ______      __        
+  /\ \      /\  == \    /\ \       
+ _\_\ \     \ \  _-/    \ \ \____  
+/\_____\     \ \_\       \ \_____\ 
+\/_____/iggy  \/_/laybook \/_____/inter            
+        """
+    )
+    linted = jpl.JiggyPlaybookLint(
+        path=playbook, skip=bool(skip.lower() in ["true", True])
+    ).run()
+
+    generate_jpl_report(linted=linted, verbose=verbose)
+
+
+def generate_jpl_report(linted: list, verbose=None):  # pragma no cover
+    """
+    Generate `Click` response for jpl linter.
+
+    Args:
+        linted: (list) - array of JiggyRule response objects
+        verbose: (count) - flag to denote response with verbosity
+
+    Returns:
+         click.echo - `with style`
+    """
+    for mark, rule, task_name in linted:
+        rule_meta = "[{}] {}:".format(rule.rule, rule.__class__.__name__)
+        if task_name:
+            rule_meta = "[{}] {} - {}:".format(
+                rule.rule, rule.__class__.__name__, task_name
+            )
+
+        if verbose:
+            click.echo(
+                "{:<50}{:<20} {}".format(
+                    rule_meta,
+                    click.style(mark, fg=MARK_TO_COLOR.get(mark)),
+                    rule.message,
+                )
+            )
+        else:
+            click.echo(
+                "{:<50}{:<50}".format(
+                    rule_meta, click.style(mark, fg=MARK_TO_COLOR.get(mark))
+                )
+            )
+
+    return exit()

--- a/jpl/rules/pipeline/__init__.py
+++ b/jpl/rules/pipeline/__init__.py
@@ -1,0 +1,1 @@
+from .pipeline import rules

--- a/jpl/rules/pipeline/pipeline.py
+++ b/jpl/rules/pipeline/pipeline.py
@@ -16,7 +16,7 @@ class ExtendedEnum(Enum):  # pragma no cover
 
 
 class Runner(ExtendedEnum):  # pragma no cover
-    """Runner Objects"""
+    """Runner types supported by Jiggy."""
 
     PARALLEL_RUNNER = "parallel"
     SEQUENTIAL_RUNNER = "sequential"
@@ -32,7 +32,7 @@ class PipelineHasRunner(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def validate_runner(self, playbook):
+    def validate_runner(self, playbook: dict) -> str:
         pipeline = playbook.get("pipeline", {})
 
         if not pipeline.get("runner"):
@@ -41,7 +41,7 @@ class PipelineHasRunner(JiggyRule):
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.validate_runner(playbook)
 
 
@@ -55,7 +55,7 @@ class RunnerIsSupported(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def validate_runner_supported(self, playbook):
+    def validate_runner_supported(self, playbook: dict) -> str:
         pipeline = playbook.get("pipeline", {})
         runner = pipeline.get("runner", "")
 
@@ -65,7 +65,7 @@ class RunnerIsSupported(JiggyRule):
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.validate_runner_supported(playbook)
 
 
@@ -79,7 +79,7 @@ class SecretsHasMetadata(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def validate_secrets(self, playbook: dict):
+    def validate_secrets(self, playbook: dict) -> str:
         """Check `secrets` metadata if exists for mandatory fields."""
         pipeline = playbook.get("pipeline", {})
         secrets = pipeline.get("secrets")
@@ -97,7 +97,7 @@ class SecretsHasMetadata(JiggyRule):
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.validate_secrets(playbook)
 
 
@@ -111,7 +111,7 @@ class SecretsLocationExists(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def validate_secrets_exists(self, playbook: dict):
+    def validate_secrets_exists(self, playbook: dict) -> str:
         """Check `secrets.location` exists."""
         pipeline = playbook.get("pipeline", {})
         secrets = pipeline.get("secrets", {})
@@ -127,7 +127,7 @@ class SecretsLocationExists(JiggyRule):
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.validate_secrets_exists(playbook)
 
 
@@ -141,7 +141,7 @@ class PipelineHasTasks(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def validate_pipeline_has_tasks(self, playbook: dict):
+    def validate_pipeline_has_tasks(self, playbook: dict) -> str:
         """Check `JiggyPlaybook.pipeline.tasks` exists."""
         pipeline = playbook.get("pipeline", {})
         tasks = pipeline.get("tasks")
@@ -152,7 +152,7 @@ class PipelineHasTasks(JiggyRule):
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.validate_pipeline_has_tasks(playbook)
 
 

--- a/jpl/rules/playbook/info.py
+++ b/jpl/rules/playbook/info.py
@@ -12,14 +12,14 @@ class PlayBookExists(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def exists(self, playbook):
+    def exists(self, playbook: dict) -> str:
         if not playbook:
             self.mark = "FAILED"
             self.message = "Jiggy Playbook is empty!"
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.exists(playbook)
 
 
@@ -33,14 +33,14 @@ class PlaybookHasName(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def has_name(self, playbook):
+    def has_name(self, playbook: dict) -> str:
         if not playbook.get("name", "").strip():
             self.mark = "FAILED"
             self.message = "Playbook `name` has not been declared."
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.has_name(playbook)
 
 
@@ -54,14 +54,14 @@ class PlaybookHasAuthor(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def has_author(self, playbook):
+    def has_author(self, playbook: dict) -> str:
         if not playbook.get("author"):
             self.mark = "WARNING"
             self.message = "Playbook `author` has not been declared."
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.has_author(playbook)
 
 
@@ -75,14 +75,14 @@ class PlaybookHasDescription(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def has_desc(self, playbook):
+    def has_desc(self, playbook: dict) -> str:
         if not playbook.get("description"):
             self.mark = "WARNING"
             self.message = "Playbook `description` has not been declared."
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.has_desc(playbook)
 
 
@@ -96,14 +96,14 @@ class PlaybookHasVersion(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def has_version(self, playbook):
+    def has_version(self, playbook: dict) -> str:
         if not playbook.get("version"):
             self.mark = "WARNING"
             self.message = "Playbook `version` has not been declared."
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.has_version(playbook)
 
 

--- a/jpl/rules/task/function.py
+++ b/jpl/rules/task/function.py
@@ -14,7 +14,7 @@ class FunctionSourceExists(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def function_exists(self, task):
+    def function_exists(self, task: dict) -> str:
         this_func = task.get("function", {})
         function_loc = this_func.get("source")
         if function_loc:
@@ -33,7 +33,7 @@ class FunctionSourceExists(JiggyRule):
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.function_exists(playbook)
 
 
@@ -47,7 +47,7 @@ class ParamHasType(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def param_has_attr_type(self, task):
+    def param_has_attr_type(self, task: dict) -> str:
         """Validate functino.params has `type` if exists."""
         this_func = task.get("function", {})
         params = this_func.get("params", [])
@@ -63,7 +63,7 @@ class ParamHasType(JiggyRule):
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.param_has_attr_type(playbook)
 
 
@@ -77,7 +77,7 @@ class ParamHasValue(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def param_has_attr_value(self, task):
+    def param_has_attr_value(self, task: dict) -> str:
         """Validate functino.params has `value` if exists."""
         this_func = task.get("function", {})
         params = this_func.get("params", [])
@@ -93,7 +93,7 @@ class ParamHasValue(JiggyRule):
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.param_has_attr_value(playbook)
 
 
@@ -107,7 +107,7 @@ class FunctionOutputIsSingular(JiggyRule):
     mark = "PASSED"
     message = ""
 
-    def validate_func_has_value(self, task):
+    def validate_func_has_value(self, task: dict) -> str:
         """Validate functino.params has type and value if exists."""
         this_func = task.get("function", {})
         output = this_func.get("output")
@@ -122,7 +122,7 @@ class FunctionOutputIsSingular(JiggyRule):
 
         return self.mark
 
-    def run(self, playbook):
+    def run(self, playbook: dict) -> str:
         return self.validate_func_has_value(playbook)
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,10 @@ setup(
     python_requires=">=3.7",
     keywords="yaml lint linter",
     packages=find_packages(),
-    install_requires=[
-        "pytest",
-        "pyyaml"
-    ],
+    install_requires=["pytest", "pyyaml", "Click"],
+    entry_points=
+        """
+    [console_scripts]
+    jpl=jpl.cli.main_cli:lint
+        """,
 )

--- a/tests/testRules/test_playbook.py
+++ b/tests/testRules/test_playbook.py
@@ -5,7 +5,8 @@ from jpl.rules.playbook.info import (
     PlaybookHasName,
     PlaybookHasAuthor,
     PlaybookHasDescription,
-    PlaybookHasVersion
+    PlaybookHasVersion,
+    PlayBookExists
 )
 
 from tests.test_utils import load_from_json
@@ -59,6 +60,11 @@ class MockPlaybook:
     @property
     def version_missing(self):
         self.data.pop("version")
+        return self.data
+
+    @property
+    def playbook_absent(self):
+        self.data = None
         return self.data
 
 
@@ -123,6 +129,22 @@ def test_playbook_has_desc(playbook, expected):
 )
 def test_playbook_has_version(playbook, expected):
     rule = PlaybookHasVersion()
+    result = rule.run(
+        playbook=playbook
+    )
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "playbook, expected",
+    [
+        (MockPlaybook().passing, "PASSED"),
+        (MockPlaybook().playbook_absent, "FAILED"),
+    ]
+)
+def test_playbook_exists(playbook, expected):
+    rule = PlayBookExists()
     result = rule.run(
         playbook=playbook
     )


### PR DESCRIPTION
![jpl](https://user-images.githubusercontent.com/24438337/74700590-0493d280-51d2-11ea-8090-bdda03ea87c7.png)
**NEW**
-Added a CLI built with `Click`
-Moved some logic over to `jpl/cli/main_cli.py` for generating `JiggyPlaybookLint` response

**USAGE**
```bash
$ jpl --help

Usage: jpl [OPTIONS]

  Click CLI entrypoint to run JiggyPlaybookLint.

  CLI Args: 
-v --verbose: Run `jpl` with verbosity. 
-s --skip: Skip "PASSED" rules in JiggyPlaybookLint Report.
-p --playbook: Location of JiggyPlaybook to lint.

  Args:     verbose: (count) - flag to denote response with verbosity
  skip: (str) - Skip "PASSED" rules in JiggyPlaybookLint Report.
  playbook: (str) - Location of JiggyPlaybook to lint.

  Returns:     click.echo - `with style`

Options:
  -v, --verbose        Run `jpl` with verbosity.
  -s, --skip TEXT      Skip `PASSED` rules in jpl report
  -p, --playbook TEXT  Filepath to Jiggy Playbook  [required]
  --help               Show this message and exit.
```

On a file
```bash
$ jpl -vv -p examples/jiggy-playbook-flawed.yml

   __        ______      __
  /\ \      /\  == \    /\ \
 _\_\ \     \ \  _-/    \ \ \____
/\_____\     \ \_\       \ \_____\
\/_____/iggy  \/_/laybook \/_____/inter

[I03] PlaybookHasDescription:                     WARNING     Playbook `description` has not been declared.
[P02] RunnerIsSupported:                          FAILED      Declared Runner: `something else` is not supported.
[P03] SecretsHasMetadata:                         FAILED      Secrets requires attribute `source`.
[F01] FunctionSourceExists - print-somethin:      FAILED      Declared path to function: `examples.utils.string_manipulation.PrintThis` does not exist.
[F02] ParamHasType - print-somethin:              FAILED      Function: `PrintThis` missing required argument `type`.
[F01] FunctionSourceExists:                       FAILED      Declared path to function: `examples.utils.string_manipulation.PrintThis` does not exist.
[T01] TaskHasName:                                FAILED      Task `name` has not been declared.
[F01] FunctionSourceExists - print-somethin-3:    FAILED      Declared path to function: `examples.utils.string_manipulation.PrintThis` does not exist.
[T02] TaskHasDescription - print-somethin-3:      WARNING     Task `description` has not been declared.
[F01] FunctionSourceExists - get-current-date:    FAILED      Declared path to function: `examples.utils.dates.GetDateTask` does not exist.
[F01] FunctionSourceExists - get-first-letter:    FAILED      Declared path to function: `examples.utils.dates.GetFirstLetter` does not exist.
[T02] TaskHasDescription - get-first-letter:      WARNING     Task `description` has not been declared.
[F01] FunctionSourceExists - get-weekday:         FAILED      Function: `None` missing attribute `source`.
[T03] TaskHasFunction - get-weekday:              FAILED      Task `function` has not been declared.
```

*EDIT*
-Made change for `-s` to be -`is_flag`
-Added further docstrings + type annotating
-Added `README.md`