### PR TITLE
[development] - Added more docs + validate method for jiggy calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.coveralls.yml
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Usage: jpl [OPTIONS]
 
   CLI Args:
   -v --verbose: Run `jpl` with verbosity.
-  -s --skip: Skip "PASSED" rules in JiggyPlaybookLint Report.
+  -s --show: Show "PASSED" rules in JiggyPlaybookLint Report.
   -p --playbook: Location of JiggyPlaybook to lint.
 
   Returns:
@@ -49,7 +49,7 @@ Usage: jpl [OPTIONS]
 
 Options:
   -v, --verbose        Run `jpl` with verbosity.
-  -s, --skip           Skip `PASSED` rules in jpl report
+  -s, --show           Show `PASSED` rules in jpl report
   -p, --playbook TEXT  Filepath to Jiggy Playbook  [required]
   --help               Show this message and exit.
 ```
@@ -67,22 +67,19 @@ $ jpl -v -p examples/jiggy-playbook.yml
 
 ```
 
-Via python client
+Via python client with `.validate()`
 ```python
 import jpl
 
 >>> client = jpl.JiggyPlaybookLint(path="path/to/playbook")
->>> client.run()
+>>> result = client.validate()
 ```
 
-```bash
-   __        ______      __
-  /\ \      /\  == \    /\ \
- _\_\ \     \ \  _-/    \ \ \____
-/\_____\     \ \_\       \ \_____\
-\/_____/iggy  \/_/laybook \/_____/inter
+The `validate()` method will return a `tuple`
 
-[F01] FunctionSourceExists - get-weekday:         FAILED      Declared path to function: `examples.utils.dates.GetWeekdayTask` does not exist.
+The tuple denotes the validity of the playbook and the failing rules as `JiggyRule` objects
+```bash
+(False, [<JiggyRule: F01>, <JiggyRule: F01>, <JiggyRule: F01>, <JiggyRule: F01>, <JiggyRule: F01>, <JiggyRule: F01>])
 ```
 
 ## Overview

--- a/jpl/cli/main_cli.py
+++ b/jpl/cli/main_cli.py
@@ -11,21 +11,21 @@ MARK_TO_COLOR = {"PASSED": "green", "WARNING": "yellow", "FAILED": "red"}
 )
 @click.option(
     "-s",
-    "--skip",
+    "--show",
     required=False,
     is_flag=True,
     default=True,
-    help="Skip `PASSED` rules in jpl report",
+    help="Show `PASSED` rules in jpl report",
 )
 @click.option("-p", "--playbook", required=True, help="Filepath to Jiggy Playbook")
-def lint(verbose, skip, playbook):
+def lint(verbose, show, playbook):
     """Click CLI entrypoint to run JiggyPlaybookLint.
 
     CLI Args:
 
     -v --verbose: Run `jpl` with verbosity.
 
-    -s --skip: Skip "PASSED" rules in JiggyPlaybookLint Report.
+    -s --show: Show "PASSED" rules in JiggyPlaybookLint Report.
 
     -p --playbook: Location of JiggyPlaybook to lint.
 
@@ -43,7 +43,7 @@ def lint(verbose, skip, playbook):
 \/_____/iggy  \/_/laybook \/_____/inter            
         """
     )
-    linted = jpl.JiggyPlaybookLint(path=playbook, skip=skip).run()
+    linted = jpl.JiggyPlaybookLint(path=playbook, show=show).run()
 
     generate_jpl_report(linted=linted, verbose=verbose)
 
@@ -59,18 +59,18 @@ def generate_jpl_report(linted: list, verbose=None):  # pragma no cover
     Returns:
          click.echo - `with style`
     """
-    for mark, rule, task_name in linted:
+    for rule in linted:
         rule_meta = "[{}] {}:".format(rule.rule, rule.__class__.__name__)
-        if task_name:
+        if rule.task:
             rule_meta = "[{}] {} - {}:".format(
-                rule.rule, rule.__class__.__name__, task_name
+                rule.rule, rule.__class__.__name__, rule.task
             )
 
         if verbose == 1:
             click.echo(
                 "{:<50}{:<20} {}".format(
                     rule_meta,
-                    click.style(mark, fg=MARK_TO_COLOR.get(mark)),
+                    click.style(rule.mark, fg=MARK_TO_COLOR.get(rule.mark)),
                     rule.message,
                 )
             )
@@ -78,7 +78,7 @@ def generate_jpl_report(linted: list, verbose=None):  # pragma no cover
             click.echo(
                 "{:<50}{:<20} {} \nPriority: `{}` - Description: `{}`\n".format(
                     rule_meta,
-                    click.style(mark, fg=MARK_TO_COLOR.get(mark)),
+                    click.style(rule.mark, fg=MARK_TO_COLOR.get(rule.mark)),
                     rule.message,
                     rule.priority,
                     rule.description,
@@ -87,7 +87,7 @@ def generate_jpl_report(linted: list, verbose=None):  # pragma no cover
         else:
             click.echo(
                 "{:<50}{:<50}".format(
-                    rule_meta, click.style(mark, fg=MARK_TO_COLOR.get(mark))
+                    rule_meta, click.style(rule.mark, fg=MARK_TO_COLOR.get(rule.mark))
                 )
             )
 

--- a/jpl/lint.py
+++ b/jpl/lint.py
@@ -1,5 +1,5 @@
 import jpl
 
 if __name__ == "__main__":
-    client = jpl.JiggyPlaybookLint(path="examples/jiggy-playbook-flawed.yml")
-    result = client.run()
+    client = jpl.JiggyPlaybookLint(path="examples/jiggy-playbook.yml")
+    result = client.validate()

--- a/jpl/rules/pipeline/pipeline.py
+++ b/jpl/rules/pipeline/pipeline.py
@@ -31,6 +31,7 @@ class PipelineHasRunner(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def validate_runner(self, playbook: dict) -> str:
         pipeline = playbook.get("pipeline", {})
@@ -54,6 +55,7 @@ class RunnerIsSupported(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def validate_runner_supported(self, playbook: dict) -> str:
         pipeline = playbook.get("pipeline", {})
@@ -78,6 +80,7 @@ class SecretsHasMetadata(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def validate_secrets(self, playbook: dict) -> str:
         """Check `secrets` metadata if exists for mandatory fields."""
@@ -110,6 +113,7 @@ class SecretsLocationExists(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def validate_secrets_exists(self, playbook: dict) -> str:
         """Check `secrets.location` exists."""
@@ -140,6 +144,7 @@ class PipelineHasTasks(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def validate_pipeline_has_tasks(self, playbook: dict) -> str:
         """Check `JiggyPlaybook.pipeline.tasks` exists."""

--- a/jpl/rules/playbook/info.py
+++ b/jpl/rules/playbook/info.py
@@ -11,6 +11,7 @@ class PlayBookExists(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def exists(self, playbook: dict) -> str:
         if not playbook:
@@ -32,6 +33,7 @@ class PlaybookHasName(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def has_name(self, playbook: dict) -> str:
         if not playbook.get("name", "").strip():
@@ -53,6 +55,7 @@ class PlaybookHasAuthor(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def has_author(self, playbook: dict) -> str:
         if not playbook.get("author"):
@@ -74,6 +77,7 @@ class PlaybookHasDescription(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def has_desc(self, playbook: dict) -> str:
         if not playbook.get("description"):
@@ -95,6 +99,7 @@ class PlaybookHasVersion(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def has_version(self, playbook: dict) -> str:
         if not playbook.get("version"):

--- a/jpl/rules/task/function.py
+++ b/jpl/rules/task/function.py
@@ -13,8 +13,10 @@ class FunctionSourceExists(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def function_exists(self, task: dict) -> str:
+        self.task = task.get("name")
         this_func = task.get("function", {})
         function_loc = this_func.get("source")
         if function_loc:
@@ -46,9 +48,11 @@ class ParamHasType(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def param_has_attr_type(self, task: dict) -> str:
         """Validate functino.params has `type` if exists."""
+        self.task = task.get("name")
         this_func = task.get("function", {})
         params = this_func.get("params", [])
         if params:
@@ -76,9 +80,11 @@ class ParamHasValue(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def param_has_attr_value(self, task: dict) -> str:
         """Validate functino.params has `value` if exists."""
+        self.task = task.get("name")
         this_func = task.get("function", {})
         params = this_func.get("params", [])
         if params:
@@ -106,9 +112,11 @@ class FunctionOutputIsSingular(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def validate_func_has_value(self, task: dict) -> str:
         """Validate functino.params has type and value if exists."""
+        self.task = task.get("name")
         this_func = task.get("function", {})
         output = this_func.get("output")
         if output:

--- a/jpl/rules/task/task.py
+++ b/jpl/rules/task/task.py
@@ -11,8 +11,10 @@ class TaskHasName(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def has_name(self, task):
+        self.task = task.get("name")
         if not task.get("name"):
             self.mark = "FAILED"
             self.message = "Task `name` has not been declared."
@@ -32,8 +34,10 @@ class TaskHasDescription(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def has_desc(self, task):
+        self.task = task.get("name")
         if not task.get("description"):
             self.mark = "WARNING"
             self.message = "Task `description` has not been declared."
@@ -53,8 +57,10 @@ class TaskHasFunction(JiggyRule):
     commands = ["command", "core"]
     mark = "PASSED"
     message = ""
+    task = None
 
     def has_function(self, task):
+        self.task = task.get("name")
         if not task.get("function"):
             self.mark = "FAILED"
             self.message = "Task `function` has not been declared."

--- a/jpl/utils/path.py
+++ b/jpl/utils/path.py
@@ -5,6 +5,7 @@ from importlib import import_module
 
 
 def file_exists(filepath: str):
+    """Validate the existence of a filepath."""
     return os.path.exists(filepath)
 
 


### PR DESCRIPTION
**NEW**
*CLI CHANGE*
-Due to the `-s` param being an `is_flag` - I've refactored it to be "show passed" instead of "skip passed"

*IMPROVEMENTS*
-Response structure now an object.
-This will help when `jiggy` is calling `jpl` to inspect and prompt users with the errors with its own interface.
-Added a new class variable to denote function name - (relates to the response objects being generated)

*DOCS*
-Amended some naming/info in README.md